### PR TITLE
Remove duplicate bib definitions

### DIFF
--- a/IFE/ST-SC.bib
+++ b/IFE/ST-SC.bib
@@ -427,32 +427,20 @@ doi = {10.1080/15361055.2019.1622971},
 
 
 @ARTICLE{Wessel2015,
-
   author={F. J. {Wessel} and  {Hafiz-Ur-Rahman} and P. {Ney} and R. {Presura}},
-
-  journal={IEEE Transactions on Plasma Science}, 
-
-  title={Fusion in a Staged  $Z$ -Pinch}, 
-
+  journal={IEEE Transactions on Plasma Science},
+  title={Fusion in a Staged  $Z$ -Pinch},
   year={2015},
-
   volume={43},
-
   number={8},
-
-  pages={2463-2468},}
-
-
-
-
-
-
-@ARTICLE{Wessel2015,
-  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
-  title = {Fusion in a Staged Z-pinch},
-  journal = {American Institute of Physics Conf. Proc.},
-  year = {2015}
+  pages={2463-2468}
 }
+%@ARTICLE{Wessel2015,
+%  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
+%  title = {Fusion in a Staged Z-pinch},
+%  journal = {American Institute of Physics Conf. Proc.},
+%  year = {2015}
+%}
 
 
 @ARTICLE{Wessel20152,
@@ -1361,6 +1349,19 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {9670862},
   timestamp = {2018.02.08},
 }
+%@article{Miller2007,
+%    author = {Ronald L. Miller},
+%    title = {Liner-Driven Pulsed Magnetized Target Fusion Power Plant},
+%    journal = {Fusion Science and Technology},
+%    volume = {52},
+%    number = {3},
+%    pages = {427-431},
+%    year  = {2007},
+%    publisher = {Taylor & Francis},
+%    doi = {10.13182/FST07-A1525},
+%    URL = {https://doi.org/10.13182/FST07-A1525},
+%    eprint = {https://doi.org/10.13182/FST07-A1525}
+%}
 
 @InProceedings{Nuttleman1980,
   author    = {Nuttleman, R.A. and Degnan, J.H. and Kiuttu, G.F. and Reinovsky, R.E. and Baker, W.L. and Turchi, P.J.},
@@ -1556,6 +1557,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {1660213},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Robson1980,
+%    author = {A. E. Robson},
+%    title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
+%    journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
+%    year = {1980}
+%}
 
 @InProceedings{Robson1976,
   author    = {Robson, A.E. and Turchi, P.J.},
@@ -1789,6 +1796,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {10054989},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Turchi2008,
+%    author = {P. J. Turchi},
+%    title = {Imploding Liner Compression of Plasma: Concepts and Issues},
+%    journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
+%    year = {2008}
+%}
 
 @Article{Turchi2008a,
   author    = {Turchi, P.J.},
@@ -1827,6 +1840,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {9138000},
   timestamp = {2018.02.08},
 }
+%@Article{Turchi2006,
+%    author  = {P.J. Turchi},
+%    journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
+%    title   = {Issues of Liner-Plasma Compression},
+%    year    = {2006},
+%}
 
 @Article{Turchi2002,
   author    = {Turchi, P.J. and Alvey, K. and Adams, C. and Anderson, B. and Anderson, H.D. and Anderson, W.E. and Armijo, E. and Atchison, W.L. and Bartos, J. and Bowers, R.L. and Cameron, B. and Cavazos, T. and Coffey, S. and Corrow, R. and Degnan, J.H. and Echave, J. and Froggett, B. and Gale, D. and Garcia, F. and Guzik, J.A. and Henneke, B. and Kanzleiter, R.J. and Kiuttu, G. and Lebeda, C. and Olson, R.T. and Oro, D. and Parker, J.V. and Peterkin, R.E., Jr. and Peterson, K. and Pritchett, R. and Randolph, R.B. and Reinovsky, R.E. and Roberts, J. and Rodriguez, G. and Sandoval, D. and Sandoval, G. and Salazar, M.A. and Sommars, W. and Steckle, W. and Stokes, J.L. and Studebaker, J. and Tabaka, L. and Taylor, A.J.},
@@ -2130,16 +2149,6 @@ doi = {10.1080/15361055.2019.1622971},
 }
 
 
-
-@ARTICLE{Robson1980,
-  author = {A. E. Robson},
-  title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
-  journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
-  year = {1980}
-}
-
- 
-
 @ARTICLE{Miller1980,
   author = {R. L. Miller and R. A. Krakowski},
   title = {Assessment of the Slowly-Imploding Liner (LINUS)},
@@ -2154,24 +2163,6 @@ doi = {10.1080/15361055.2019.1622971},
   title = {A LINUS Fusion Reactor Design Based on Axisymmetric Implosion of Tangentially-Injected Liquid Metal},
   journal = {Naval Research Laboratory Memorandum Report 4388},
   year = {1981}
-}
-
- 
-
-@Article{Turchi2006,
-  author  = {P.J. Turchi},
-  journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
-  title   = {Issues of Liner-Plasma Compression},
-  year    = {2006},
-}
-
- 
-
-@ARTICLE{Turchi2008,
-  author = {P. J. Turchi},
-  title = {Imploding Liner Compression of Plasma: Concepts and Issues},
-  journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
-  year = {2008}
 }
 
 
@@ -2213,30 +2204,6 @@ doi = {10.1080/15361055.2019.1622971},
   title = {Thermal Energy Conversion Systems Overview for Fusion Reactors},
   journal = {Fusion Technology, 16, 2, 211-234.},
   year = {1989}
-}
-
-
-
-
-
-
-
-
-
-@article{Miller2007,
-author = {Ronald L. Miller},
-title = {Liner-Driven Pulsed Magnetized Target Fusion Power Plant},
-journal = {Fusion Science and Technology},
-volume = {52},
-number = {3},
-pages = {427-431},
-year  = {2007},
-publisher = {Taylor & Francis},
-doi = {10.13182/FST07-A1525},
-
-URL = {https://doi.org/10.13182/FST07-A1525},
-eprint = {https://doi.org/10.13182/FST07-A1525}
-
 }
 
 @article{Bechtel2017,

--- a/MFE/ST-SC.bib
+++ b/MFE/ST-SC.bib
@@ -427,32 +427,20 @@ doi = {10.1080/15361055.2019.1622971},
 
 
 @ARTICLE{Wessel2015,
-
   author={F. J. {Wessel} and  {Hafiz-Ur-Rahman} and P. {Ney} and R. {Presura}},
-
-  journal={IEEE Transactions on Plasma Science}, 
-
-  title={Fusion in a Staged  $Z$ -Pinch}, 
-
+  journal={IEEE Transactions on Plasma Science},
+  title={Fusion in a Staged  $Z$ -Pinch},
   year={2015},
-
   volume={43},
-
   number={8},
-
-  pages={2463-2468},}
-
-
-
-
-
-
-@ARTICLE{Wessel2015,
-  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
-  title = {Fusion in a Staged Z-pinch},
-  journal = {American Institute of Physics Conf. Proc.},
-  year = {2015}
+  pages={2463-2468}
 }
+%@ARTICLE{Wessel2015,
+%  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
+%  title = {Fusion in a Staged Z-pinch},
+%  journal = {American Institute of Physics Conf. Proc.},
+%  year = {2015}
+%}
 
 
 @ARTICLE{Wessel20152,
@@ -1556,6 +1544,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {1660213},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Robson1980,
+%    author = {A. E. Robson},
+%    title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
+%    journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
+%    year = {1980}
+%}
 
 @InProceedings{Robson1976,
   author    = {Robson, A.E. and Turchi, P.J.},
@@ -1789,6 +1783,22 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {10054989},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Turchi2008,
+%    author = {P. J. Turchi},
+%    title = {Imploding Liner Compression of Plasma: Concepts and Issues},
+%    journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
+%    year = {2008}
+%}
+%@INPROCEEDINGS{Turchi2008,
+%    author = {Turchi, Peter J and Roderick, Norman F and Degnan, James H and Frese,
+%	Michael H},
+%    title = {Plasma guns for controlled fusion at megagauss energy-densities},
+%    year = {2008},
+%    month = jan,
+%    owner = {simon},
+%    timestamp = {2011.08.10},
+%    url = {http://www.osti.gov/bridge/servlets/purl/957735-PvESM1/}
+%}
 
 @Article{Turchi2008a,
   author    = {Turchi, P.J.},
@@ -1827,6 +1837,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {9138000},
   timestamp = {2018.02.08},
 }
+%@Article{Turchi2006,
+%    author  = {P.J. Turchi},
+%    journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
+%    title   = {Issues of Liner-Plasma Compression},
+%    year    = {2006},
+%}
 
 @Article{Turchi2002,
   author    = {Turchi, P.J. and Alvey, K. and Adams, C. and Anderson, B. and Anderson, H.D. and Anderson, W.E. and Armijo, E. and Atchison, W.L. and Bartos, J. and Bowers, R.L. and Cameron, B. and Cavazos, T. and Coffey, S. and Corrow, R. and Degnan, J.H. and Echave, J. and Froggett, B. and Gale, D. and Garcia, F. and Guzik, J.A. and Henneke, B. and Kanzleiter, R.J. and Kiuttu, G. and Lebeda, C. and Olson, R.T. and Oro, D. and Parker, J.V. and Peterkin, R.E., Jr. and Peterson, K. and Pritchett, R. and Randolph, R.B. and Reinovsky, R.E. and Roberts, J. and Rodriguez, G. and Sandoval, D. and Sandoval, G. and Salazar, M.A. and Sommars, W. and Steckle, W. and Stokes, J.L. and Studebaker, J. and Tabaka, L. and Taylor, A.J.},
@@ -2130,16 +2146,6 @@ doi = {10.1080/15361055.2019.1622971},
 }
 
 
-
-@ARTICLE{Robson1980,
-  author = {A. E. Robson},
-  title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
-  journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
-  year = {1980}
-}
-
- 
-
 @ARTICLE{Miller1980,
   author = {R. L. Miller and R. A. Krakowski},
   title = {Assessment of the Slowly-Imploding Liner (LINUS)},
@@ -2154,24 +2160,6 @@ doi = {10.1080/15361055.2019.1622971},
   title = {A LINUS Fusion Reactor Design Based on Axisymmetric Implosion of Tangentially-Injected Liquid Metal},
   journal = {Naval Research Laboratory Memorandum Report 4388},
   year = {1981}
-}
-
- 
-
-@Article{Turchi2006,
-  author  = {P.J. Turchi},
-  journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
-  title   = {Issues of Liner-Plasma Compression},
-  year    = {2006},
-}
-
- 
-
-@ARTICLE{Turchi2008,
-  author = {P. J. Turchi},
-  title = {Imploding Liner Compression of Plasma: Concepts and Issues},
-  journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
-  year = {2008}
 }
 
 
@@ -2215,29 +2203,6 @@ doi = {10.1080/15361055.2019.1622971},
   year = {1989}
 }
 
-
-
-
-
-
-
-
-
-@article{Miller2007,
-author = {Ronald L. Miller},
-title = {Liner-Driven Pulsed Magnetized Target Fusion Power Plant},
-journal = {Fusion Science and Technology},
-volume = {52},
-number = {3},
-pages = {427-431},
-year  = {2007},
-publisher = {Taylor & Francis},
-doi = {10.13182/FST07-A1525},
-
-URL = {https://doi.org/10.13182/FST07-A1525},
-eprint = {https://doi.org/10.13182/FST07-A1525}
-
-}
 
 @article{Bechtel2017,
 title = {{Conceptual Cost Study for a Fusion Power Plant Based on Four Technologies from the DOE ARPA-E ALPHA Program}},
@@ -31596,16 +31561,6 @@ Proceedings of the IAEA Technical Committee Meeting and Workshop on Fusion React
   url = {http://dx.doi.org/10.1109/MEGAGUSS.2006.4530660}
 }
 
-@INPROCEEDINGS{Turchi2008,
-  author = {Turchi, Peter J and Roderick, Norman F and Degnan, James H and Frese,
-	Michael H},
-  title = {Plasma guns for controlled fusion at megagauss energy-densities},
-  year = {2008},
-  month = jan,
-  owner = {simon},
-  timestamp = {2011.08.10},
-  url = {http://www.osti.gov/bridge/servlets/purl/957735-PvESM1/}
-}
 
 @Article{Turkington1993/06/,
   author    = {Turkington, B. and Lifschitz, A. and Eydeland, A. and Spruck, J.},

--- a/MIF/ST-SC.bib
+++ b/MIF/ST-SC.bib
@@ -427,32 +427,20 @@ doi = {10.1080/15361055.2019.1622971},
 
 
 @ARTICLE{Wessel2015,
-
   author={F. J. {Wessel} and  {Hafiz-Ur-Rahman} and P. {Ney} and R. {Presura}},
-
-  journal={IEEE Transactions on Plasma Science}, 
-
-  title={Fusion in a Staged  $Z$ -Pinch}, 
-
+  journal={IEEE Transactions on Plasma Science},
+  title={Fusion in a Staged  $Z$ -Pinch},
   year={2015},
-
   volume={43},
-
   number={8},
-
-  pages={2463-2468},}
-
-
-
-
-
-
-@ARTICLE{Wessel2015,
-  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
-  title = {Fusion in a Staged Z-pinch},
-  journal = {American Institute of Physics Conf. Proc.},
-  year = {2015}
+  pages={2463-2468}
 }
+%@ARTICLE{Wessel2015,
+%  author = {F. J. Wessel and H. U. Rahman and \begin{it} et al. \end{it}},
+%  title = {Fusion in a Staged Z-pinch},
+%  journal = {American Institute of Physics Conf. Proc.},
+%  year = {2015}
+%}
 
 
 @ARTICLE{Wessel20152,
@@ -1361,6 +1349,19 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {9670862},
   timestamp = {2018.02.08},
 }
+%@article{Miller2007,
+%    author = {Ronald L. Miller},
+%    title = {Liner-Driven Pulsed Magnetized Target Fusion Power Plant},
+%    journal = {Fusion Science and Technology},
+%    volume = {52},
+%    number = {3},
+%    pages = {427-431},
+%    year  = {2007},
+%    publisher = {Taylor & Francis},
+%    doi = {10.13182/FST07-A1525},
+%    URL = {https://doi.org/10.13182/FST07-A1525},
+%    eprint = {https://doi.org/10.13182/FST07-A1525}
+%}
 
 @InProceedings{Nuttleman1980,
   author    = {Nuttleman, R.A. and Degnan, J.H. and Kiuttu, G.F. and Reinovsky, R.E. and Baker, W.L. and Turchi, P.J.},
@@ -1556,6 +1557,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {1660213},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Robson1980,
+%    author = {A. E. Robson},
+%    title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
+%    journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
+%    year = {1980}
+%}
 
 @InProceedings{Robson1976,
   author    = {Robson, A.E. and Turchi, P.J.},
@@ -1789,6 +1796,22 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {10054989},
   timestamp = {2018.02.08},
 }
+%@ARTICLE{Turchi2008,
+%    author = {P. J. Turchi},
+%    title = {Imploding Liner Compression of Plasma: Concepts and Issues},
+%    journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
+%    year = {2008}
+%}
+%@INPROCEEDINGS{Turchi2008,
+%    author = {Turchi, Peter J and Roderick, Norman F and Degnan, James H and Frese,
+%	Michael H},
+%    title = {Plasma guns for controlled fusion at megagauss energy-densities},
+%    year = {2008},
+%    month = jan,
+%    owner = {simon},
+%    timestamp = {2011.08.10},
+%    url = {http://www.osti.gov/bridge/servlets/purl/957735-PvESM1/}
+%}
 
 @Article{Turchi2008a,
   author    = {Turchi, P.J.},
@@ -1827,6 +1850,12 @@ doi = {10.1080/15361055.2019.1622971},
   refid     = {9138000},
   timestamp = {2018.02.08},
 }
+%@Article{Turchi2006,
+%    author  = {P.J. Turchi},
+%    journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
+%    title   = {Issues of Liner-Plasma Compression},
+%    year    = {2006},
+%}
 
 @Article{Turchi2002,
   author    = {Turchi, P.J. and Alvey, K. and Adams, C. and Anderson, B. and Anderson, H.D. and Anderson, W.E. and Armijo, E. and Atchison, W.L. and Bartos, J. and Bowers, R.L. and Cameron, B. and Cavazos, T. and Coffey, S. and Corrow, R. and Degnan, J.H. and Echave, J. and Froggett, B. and Gale, D. and Garcia, F. and Guzik, J.A. and Henneke, B. and Kanzleiter, R.J. and Kiuttu, G. and Lebeda, C. and Olson, R.T. and Oro, D. and Parker, J.V. and Peterkin, R.E., Jr. and Peterson, K. and Pritchett, R. and Randolph, R.B. and Reinovsky, R.E. and Roberts, J. and Rodriguez, G. and Sandoval, D. and Sandoval, G. and Salazar, M.A. and Sommars, W. and Steckle, W. and Stokes, J.L. and Studebaker, J. and Tabaka, L. and Taylor, A.J.},
@@ -2130,16 +2159,6 @@ doi = {10.1080/15361055.2019.1622971},
 }
 
 
-
-@ARTICLE{Robson1980,
-  author = {A. E. Robson},
-  title = {A Conceptual Design for an Imploding-Liner Fusion Reactor},
-  journal = {MegaGauss Physics and Technology, (Plenum Press, New York and London) 425},
-  year = {1980}
-}
-
- 
-
 @ARTICLE{Miller1980,
   author = {R. L. Miller and R. A. Krakowski},
   title = {Assessment of the Slowly-Imploding Liner (LINUS)},
@@ -2154,24 +2173,6 @@ doi = {10.1080/15361055.2019.1622971},
   title = {A LINUS Fusion Reactor Design Based on Axisymmetric Implosion of Tangentially-Injected Liquid Metal},
   journal = {Naval Research Laboratory Memorandum Report 4388},
   year = {1981}
-}
-
- 
-
-@Article{Turchi2006,
-  author  = {P.J. Turchi},
-  journal = {2006 International Conference on Megagauss Magnetic Field Generation and Related Topics, Santa Fe, NM},
-  title   = {Issues of Liner-Plasma Compression},
-  year    = {2006},
-}
-
- 
-
-@ARTICLE{Turchi2008,
-  author = {P. J. Turchi},
-  title = {Imploding Liner Compression of Plasma: Concepts and Issues},
-  journal = {IEEE Transactions on Plasma Science, 36, 1, 52-61},
-  year = {2008}
 }
 
 
@@ -2215,29 +2216,6 @@ doi = {10.1080/15361055.2019.1622971},
   year = {1989}
 }
 
-
-
-
-
-
-
-
-
-@article{Miller2007,
-author = {Ronald L. Miller},
-title = {Liner-Driven Pulsed Magnetized Target Fusion Power Plant},
-journal = {Fusion Science and Technology},
-volume = {52},
-number = {3},
-pages = {427-431},
-year  = {2007},
-publisher = {Taylor & Francis},
-doi = {10.13182/FST07-A1525},
-
-URL = {https://doi.org/10.13182/FST07-A1525},
-eprint = {https://doi.org/10.13182/FST07-A1525}
-
-}
 
 @article{Bechtel2017,
 title = {{Conceptual Cost Study for a Fusion Power Plant Based on Four Technologies from the DOE ARPA-E ALPHA Program}},
@@ -31596,16 +31574,6 @@ Proceedings of the IAEA Technical Committee Meeting and Workshop on Fusion React
   url = {http://dx.doi.org/10.1109/MEGAGUSS.2006.4530660}
 }
 
-@INPROCEEDINGS{Turchi2008,
-  author = {Turchi, Peter J and Roderick, Norman F and Degnan, James H and Frese,
-	Michael H},
-  title = {Plasma guns for controlled fusion at megagauss energy-densities},
-  year = {2008},
-  month = jan,
-  owner = {simon},
-  timestamp = {2011.08.10},
-  url = {http://www.osti.gov/bridge/servlets/purl/957735-PvESM1/}
-}
 
 @Article{Turkington1993/06/,
   author    = {Turkington, B. and Lifschitz, A. and Eydeland, A. and Spruck, J.},


### PR DESCRIPTION
Duplicate citations don't compile in latex (at least on mac & linux). I left the old citations commented out.